### PR TITLE
Compact projections periodically.

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1,0 +1,47 @@
+package verity
+
+import (
+	"context"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/verity/handler/projection"
+	"github.com/dogmatiq/verity/internal/x/loggingx"
+	"golang.org/x/sync/errgroup"
+)
+
+// runCompactorsForApp runs a projection compactor for a each projection with
+// a specific application.
+func (e *Engine) runCompactorsForApp(ctx context.Context, a *app) error {
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, h := range a.Config.RichHandlers().Projections() {
+		h := h // capture loop variable
+		g.Go(func() error {
+			return e.runCompactorForProjection(ctx, h, a)
+		})
+	}
+
+	return g.Wait()
+}
+
+// runCompactorForProjection runs a projection compactor for a specific
+// projection.
+func (e *Engine) runCompactorForProjection(
+	ctx context.Context,
+	h configkit.RichProjection,
+	a *app,
+) error {
+	c := &projection.Compactor{
+		Handler:  h.Handler(),
+		Interval: e.opts.ProjectionCompactInterval,
+		Timeout:  e.opts.ProjectionCompactTimeout,
+		Logger: loggingx.WithPrefix(
+			e.logger,
+			"[compactor %s@%s] ",
+			h.Identity().Name,
+			a.Config.Identity().Name,
+		),
+	}
+
+	return c.Run(ctx)
+}

--- a/compaction.go
+++ b/compaction.go
@@ -32,9 +32,10 @@ func (e *Engine) runCompactorForProjection(
 	a *app,
 ) error {
 	c := &projection.Compactor{
-		Handler:  h.Handler(),
-		Interval: e.opts.ProjectionCompactInterval,
-		Timeout:  e.opts.ProjectionCompactTimeout,
+		Handler:   h.Handler(),
+		Interval:  e.opts.ProjectionCompactInterval,
+		Timeout:   e.opts.ProjectionCompactTimeout,
+		Semaphore: e.semaphore,
 		Logger: loggingx.WithPrefix(
 			e.logger,
 			"[compactor %s@%s] ",

--- a/compaction.go
+++ b/compaction.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// runCompactorsForApp runs a compactor for a each projection within a specific
+// runCompactorsForApp runs a compactor for each projection within a specific
 // application.
 func (e *Engine) runCompactorsForApp(ctx context.Context, a *app) error {
 	g, ctx := errgroup.WithContext(ctx)

--- a/compaction.go
+++ b/compaction.go
@@ -9,8 +9,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// runCompactorsForApp runs a projection compactor for a each projection with
-// a specific application.
+// runCompactorsForApp runs a compactor for a each projection within a specific
+// application.
 func (e *Engine) runCompactorsForApp(ctx context.Context, a *app) error {
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -24,8 +24,7 @@ func (e *Engine) runCompactorsForApp(ctx context.Context, a *app) error {
 	return g.Wait()
 }
 
-// runCompactorForProjection runs a projection compactor for a specific
-// projection.
+// runCompactorForProjection runs a compactor for a specific projection.
 func (e *Engine) runCompactorForProjection(
 	ctx context.Context,
 	h configkit.RichProjection,

--- a/engine.go
+++ b/engine.go
@@ -117,6 +117,10 @@ func (e *Engine) run(ctx context.Context) error {
 		g.Go(func() error {
 			return e.runStreamConsumersForEachApp(ctx, a.EventStream)
 		})
+
+		g.Go(func() error {
+			return e.runCompactorsForApp(ctx, a)
+		})
 	}
 
 	err := g.Wait()

--- a/engineoption.go
+++ b/engineoption.go
@@ -52,13 +52,13 @@ var (
 	// DefaultProjectionCompactInterval is the default interval at which the
 	// engine compacts projections.
 	//
-	// It is overridden by the WithProjectionComapctInterval() option.
+	// It is overridden by the WithProjectionCompactInterval() option.
 	DefaultProjectionCompactInterval = 24 * time.Hour
 
 	// DefaultProjectionCompactTimeout is the default timeout to use when
 	// compacting a projection.
 	//
-	// It is overridden by the WithProjectionComapctTimeout() option.
+	// It is overridden by the WithProjectionCompactTimeout() option.
 	DefaultProjectionCompactTimeout = 5 * time.Minute
 
 	// DefaultLogger is the default target for log messages produced by the

--- a/engineoption.go
+++ b/engineoption.go
@@ -44,7 +44,7 @@ var (
 	)
 
 	// DefaultConcurrencyLimit is the default number of messages to handle
-	// concurrently.
+	// (and projections to compact) concurrently.
 	//
 	// It is overridden by the WithConcurrencyLimit() option.
 	DefaultConcurrencyLimit = uint(runtime.GOMAXPROCS(0) * 2)
@@ -133,7 +133,8 @@ func WithMessageBackoff(s backoff.Strategy) EngineOption {
 }
 
 // WithConcurrencyLimit returns an engine option that limits the number of
-// messages that will be handled at the same time.
+// messages that will be handled (and projections that will be compacted) at the
+// same time.
 //
 // If this option is omitted or n non-positive DefaultConcurrencyLimit is used.
 func WithConcurrencyLimit(n uint) EngineOption {

--- a/engineoption.go
+++ b/engineoption.go
@@ -143,7 +143,7 @@ func WithConcurrencyLimit(n uint) EngineOption {
 	}
 }
 
-// WithProjectionCompactInterval returns an engine option that set the interval
+// WithProjectionCompactInterval returns an engine option that sets the interval
 // at which projections are compacted.
 //
 // If this option is omitted or d is zero DefaultProjectionCompactInterval is
@@ -158,8 +158,8 @@ func WithProjectionCompactInterval(d time.Duration) EngineOption {
 	}
 }
 
-// WithProjectionCompactTimeout returns an engine option that set the duration
-// the engine allows for a single projectiont to be compacted.
+// WithProjectionCompactTimeout returns an engine option that sets the duration
+// the engine allows for a single projection to be compacted.
 //
 // If this option is omitted or d is zero DefaultProjectionCompactTimeout is
 // used.

--- a/engineoption_test.go
+++ b/engineoption_test.go
@@ -149,6 +149,58 @@ var _ = Describe("func WithConcurrencyLimit()", func() {
 	})
 })
 
+var _ = Describe("func WithProjectionCompactInterval()", func() {
+	It("sets the compaction interval", func() {
+		opts := resolveEngineOptions(
+			WithApplication(TestApplication),
+			WithProjectionCompactInterval(10*time.Minute),
+		)
+
+		Expect(opts.ProjectionCompactInterval).To(Equal(10 * time.Minute))
+	})
+
+	It("uses the default if the duration is zero", func() {
+		opts := resolveEngineOptions(
+			WithApplication(TestApplication),
+			WithProjectionCompactInterval(0),
+		)
+
+		Expect(opts.ProjectionCompactInterval).To(Equal(DefaultProjectionCompactInterval))
+	})
+
+	It("panics if the duration is less than zero", func() {
+		Expect(func() {
+			WithProjectionCompactInterval(-1)
+		}).To(Panic())
+	})
+})
+
+var _ = Describe("func WithProjectionCompactTimeout()", func() {
+	It("sets the compaction timeout", func() {
+		opts := resolveEngineOptions(
+			WithApplication(TestApplication),
+			WithProjectionCompactTimeout(10*time.Minute),
+		)
+
+		Expect(opts.ProjectionCompactTimeout).To(Equal(10 * time.Minute))
+	})
+
+	It("uses the default if the duration is zero", func() {
+		opts := resolveEngineOptions(
+			WithApplication(TestApplication),
+			WithProjectionCompactTimeout(0),
+		)
+
+		Expect(opts.ProjectionCompactTimeout).To(Equal(DefaultProjectionCompactTimeout))
+	})
+
+	It("panics if the duration is less than zero", func() {
+		Expect(func() {
+			WithProjectionCompactTimeout(-1)
+		}).To(Panic())
+	})
+})
+
 var _ = Describe("func WithMarshaler()", func() {
 	It("sets the marshaler", func() {
 		m := &codec.Marshaler{}

--- a/handler/projection/compactor.go
+++ b/handler/projection/compactor.go
@@ -1,0 +1,85 @@
+package projection
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/linger"
+)
+
+const (
+	// DefaultCompactionInterval is the default interval at which a projector
+	// will compact its projection.
+	DefaultCompactionInterval = 24 * time.Hour
+
+	// DefaultCompactionTimeout is the default timeout to use when compacting a
+	// projection.
+	DefaultCompactionTimeout = 5 * time.Minute
+)
+
+// Compactor periodically compacts a projection.
+type Compactor struct {
+	// Handler is the projection message handler to be compacted.
+	Handler dogma.ProjectionMessageHandler
+
+	// CompactionInterval is the interval at which the projection is compacted.
+	// If it is zero the global DefaultCompactionInterval constant is used.
+	CompactionInterval time.Duration
+
+	// CompactionTimeout is the default timeout to use when compacting
+	// the projection. If it is zero the global DefaultCompactionTimeout is
+	// used.
+	CompactionTimeout time.Duration
+
+	// Logger is the target for log messages produced about compaction.
+	// If it is nil, logging.DefaultLogger is used.
+	Logger logging.Logger
+}
+
+// Run periodically compacts the projection until ctx is canceled or an error
+// occurs.
+func (c *Compactor) Run(ctx context.Context) error {
+	for {
+		if err := c.compact(ctx); err != nil {
+			return err
+		}
+
+		if err := linger.Sleep(ctx, c.CompactionInterval, DefaultCompactionInterval); err != nil {
+			return err
+		}
+	}
+}
+
+// compact performs compaction. It returns an error if compaction fails for any
+// reason other than a timeout.
+func (c *Compactor) compact(ctx context.Context) error {
+	ctx, cancel := linger.ContextWithTimeout(
+		ctx,
+		c.CompactionTimeout,
+		DefaultCompactionTimeout,
+	)
+	defer cancel()
+
+	if err := c.Handler.Compact(
+		ctx,
+		compactScope{
+			logger: c.Logger,
+		},
+	); err != nil {
+		if err != context.DeadlineExceeded {
+			// The error was something other than a timeout of the compaction
+			// process itself.
+			return err
+		}
+
+		// Otherwise, the compaction timed out, but this is allowed. Log about
+		// it but continue as normal.
+		logging.Log(c.Logger, "compaction timed out, retrying later")
+	}
+
+	logging.Log(c.Logger, "compaction completed")
+
+	return nil
+}

--- a/handler/projection/compactor_test.go
+++ b/handler/projection/compactor_test.go
@@ -1,0 +1,103 @@
+package projection_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/verity/handler/projection"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Compactor", func() {
+	var (
+		logger    *logging.BufferedLogger
+		handler   *ProjectionMessageHandler
+		compactor *Compactor
+	)
+
+	BeforeEach(func() {
+		logger = &logging.BufferedLogger{}
+		handler = &ProjectionMessageHandler{}
+		compactor = &Compactor{
+			Handler: handler,
+			Logger:  logger,
+		}
+	})
+
+	Describe("func Run()", func() {
+		It("compacts immediately", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			handler.CompactFunc = func(
+				context.Context,
+				dogma.ProjectionCompactScope,
+			) error {
+				cancel()
+				return nil
+			}
+
+			err := compactor.Run(ctx)
+			Expect(err).To(Equal(context.Canceled))
+		})
+
+		It("compacts repeatedly", func() {
+			compactor.CompactionInterval = 1 * time.Millisecond
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			called := true
+			handler.CompactFunc = func(
+				context.Context,
+				dogma.ProjectionCompactScope,
+			) error {
+				if called {
+					cancel()
+				}
+
+				called = true
+				return nil
+			}
+
+			err := compactor.Run(ctx)
+			Expect(err).To(Equal(context.Canceled))
+		})
+
+		It("returns an error if compaction fails", func() {
+			handler.CompactFunc = func(
+				context.Context,
+				dogma.ProjectionCompactScope,
+			) error {
+				return errors.New("<error>")
+			}
+
+			err := compactor.Run(context.Background())
+			Expect(err).To(MatchError("<error>"))
+		})
+
+		It("does not return an error compaction times out", func() {
+			compactor.CompactionTimeout = 1 * time.Millisecond
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			handler.CompactFunc = func(
+				compactCtx context.Context,
+				_ dogma.ProjectionCompactScope,
+			) error {
+				<-compactCtx.Done()
+				cancel() // cancel the parent ctx only after the compactCtx is already done
+				return compactCtx.Err()
+			}
+
+			err := compactor.Run(ctx)
+			Expect(err).To(Equal(context.Canceled)) // canceled, not deadline exceeded
+		})
+	})
+})

--- a/handler/projection/compactor_test.go
+++ b/handler/projection/compactor_test.go
@@ -71,7 +71,7 @@ var _ = Describe("type Compactor", func() {
 			Expect(err).To(Equal(context.Canceled))
 		})
 
-		It("returns if the context is canceled while waiting for the sempahore", func() {
+		It("returns an error if the context is canceled while waiting for the semaphore", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -100,7 +100,7 @@ var _ = Describe("type Compactor", func() {
 			Expect(err).To(MatchError("<error>"))
 		})
 
-		It("does not return an error compaction times out", func() {
+		It("does not return an error if compaction times out", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 

--- a/handler/projection/compactor_test.go
+++ b/handler/projection/compactor_test.go
@@ -24,8 +24,10 @@ var _ = Describe("type Compactor", func() {
 		logger = &logging.BufferedLogger{}
 		handler = &ProjectionMessageHandler{}
 		compactor = &Compactor{
-			Handler: handler,
-			Logger:  logger,
+			Handler:  handler,
+			Interval: 1 * time.Millisecond,
+			Timeout:  1 * time.Millisecond,
+			Logger:   logger,
 		}
 	})
 
@@ -47,8 +49,6 @@ var _ = Describe("type Compactor", func() {
 		})
 
 		It("compacts repeatedly", func() {
-			compactor.CompactionInterval = 1 * time.Millisecond
-
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
@@ -82,8 +82,6 @@ var _ = Describe("type Compactor", func() {
 		})
 
 		It("does not return an error compaction times out", func() {
-			compactor.CompactionTimeout = 1 * time.Millisecond
-
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 

--- a/handler/projection/scope.go
+++ b/handler/projection/scope.go
@@ -8,20 +8,20 @@ import (
 	"github.com/dogmatiq/verity/parcel"
 )
 
-// scope is an implementation of dogma.ProjectionEventScope.
-type scope struct {
+// eventScope is an implementation of dogma.ProjectionEventScope.
+type eventScope struct {
 	cause  parcel.Parcel
 	logger logging.Logger
 }
 
 // RecordedAt returns the time at which the event was recorded.
-func (s scope) RecordedAt() time.Time {
+func (s eventScope) RecordedAt() time.Time {
 	return s.cause.CreatedAt
 }
 
 // Log records an informational message within the context of the message
 // that is being handled.
-func (s scope) Log(f string, v ...interface{}) {
+func (s eventScope) Log(f string, v ...interface{}) {
 	mlog.LogFromScope(
 		s.logger,
 		s.cause.Envelope,

--- a/handler/projection/scope.go
+++ b/handler/projection/scope.go
@@ -29,3 +29,13 @@ func (s eventScope) Log(f string, v ...interface{}) {
 		v,
 	)
 }
+
+// compactScope is an implementation of dogma.ProjectionCompactScope.
+type compactScope struct {
+	logger logging.Logger
+}
+
+// Log records an informational message within the context of compaction.
+func (s compactScope) Log(f string, v ...interface{}) {
+	logging.Log(s.logger, f, v...)
+}

--- a/handler/projection/scope_test.go
+++ b/handler/projection/scope_test.go
@@ -8,16 +8,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("type scope", func() {
+var _ = Describe("type eventScope", func() {
 	var (
 		logger *logging.BufferedLogger
-		sc     *scope
+		sc     *eventScope
 	)
 
 	BeforeEach(func() {
 		logger = &logging.BufferedLogger{}
 
-		sc = &scope{
+		sc = &eventScope{
 			cause:  NewParcel("<consume>", MessageC1),
 			logger: logger,
 		}

--- a/handler/projection/scope_test.go
+++ b/handler/projection/scope_test.go
@@ -43,3 +43,30 @@ var _ = Describe("type eventScope", func() {
 		})
 	})
 })
+
+var _ = Describe("type compactScope", func() {
+	var (
+		logger *logging.BufferedLogger
+		sc     *compactScope
+	)
+
+	BeforeEach(func() {
+		logger = &logging.BufferedLogger{}
+
+		sc = &compactScope{
+			logger: logger,
+		}
+	})
+
+	Describe("func Log()", func() {
+		It("logs a message", func() {
+			sc.Log("format %s", "<value>")
+
+			Expect(logger.Messages()).To(ContainElement(
+				logging.BufferedLogMessage{
+					Message: "format <value>",
+				},
+			))
+		})
+	})
+})

--- a/handler/projection/stream.go
+++ b/handler/projection/stream.go
@@ -90,7 +90,7 @@ func (a *StreamAdaptor) HandleEvent(
 		resource.FromApplicationKey(ak),
 		resource.MarshalOffset(o),
 		resource.MarshalOffset(ev.Offset+1),
-		scope{
+		eventScope{
 			cause:  ev.Parcel,
 			logger: a.Logger,
 		},


### PR DESCRIPTION
#### What change does this introduce?

This PR implements projection compaction, as introduced in Dogma v0.10.0.

In the interest of simplicity I ended up just running compaction at a fixed interval. I had made some more advanced proposals in #354.

Every projection is compacted on start up. To ensure that applications with a large number of projections do not stampede the database the "compactors" honour the same concurrency limit as message handlers (see the `WithConcurrencyLimit()` engine option). 


#### What issues does this relate to?

Fixes #354

#### Why make this change?

Compaction was introduced to clean-up application read-model data. It is the engine's responsibility to schedule this compaction.

#### Is there anything you are unsure about?

I've used a rather generous compaction timeout of 5 minutes. This is the default in `dogmatiq/aperture` as well. This should perhaps be reduced but it's hard to say. The Dogma documentation suggests that compaction be performed as multiple small transactions so that large projections can at least be "partially compacted" within the timeout period.