### PR TITLE
Use the new `discoverkit` module for gRPC discovery.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/dogmatiq/verity
 go 1.15
 
 require (
-	github.com/dogmatiq/configkit v0.9.1
+	github.com/dogmatiq/configkit v0.9.2-0.20210112084953-158c931503a6
 	github.com/dogmatiq/cosyne v0.2.0
+	github.com/dogmatiq/discoverkit v0.0.0-20210115020954-2f11f8a1362e
 	github.com/dogmatiq/dodeca v0.2.2
 	github.com/dogmatiq/dogma v0.10.0
 	github.com/dogmatiq/envelopespec v0.2.0
 	github.com/dogmatiq/iago v0.4.0
+	github.com/dogmatiq/interopspec v0.4.1-0.20210107013954-d93daeb19c6b
 	github.com/dogmatiq/kyu v0.2.0
 	github.com/dogmatiq/linger v0.2.1
 	github.com/dogmatiq/marshalkit v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/dogmatiq/verity
 go 1.15
 
 require (
-	github.com/dogmatiq/configkit v0.9.2-0.20210112084953-158c931503a6
+	github.com/dogmatiq/configkit v0.10.0
 	github.com/dogmatiq/cosyne v0.2.0
-	github.com/dogmatiq/discoverkit v0.0.0-20210115020954-2f11f8a1362e
+	github.com/dogmatiq/discoverkit v0.1.1
 	github.com/dogmatiq/dodeca v0.2.2
 	github.com/dogmatiq/dogma v0.10.0
 	github.com/dogmatiq/envelopespec v0.2.0
 	github.com/dogmatiq/iago v0.4.0
-	github.com/dogmatiq/interopspec v0.4.1-0.20210107013954-d93daeb19c6b
+	github.com/dogmatiq/interopspec v0.5.0
 	github.com/dogmatiq/kyu v0.2.0
 	github.com/dogmatiq/linger v0.2.1
 	github.com/dogmatiq/marshalkit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
@@ -14,10 +15,13 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dogmatiq/configkit v0.8.0/go.mod h1:tJMAdqnx+H0q8mqBwp6z8NbnxRql/ImLgUyQkkip69A=
-github.com/dogmatiq/configkit v0.9.1 h1:gx2egDrmeiel1m8/RwAOk3ZFlvZa1mmElPz9v1K0AzY=
 github.com/dogmatiq/configkit v0.9.1/go.mod h1:lchVdCxCweenWrmm9WlgRH9X7Ppb340CvilcoVdTE8c=
+github.com/dogmatiq/configkit v0.9.2-0.20210112084953-158c931503a6 h1:EYSv4w5cxGa9FnLeRJM7mRJ3JQeRXTdT9KuNA0qlMns=
+github.com/dogmatiq/configkit v0.9.2-0.20210112084953-158c931503a6/go.mod h1:JVZG0CR5RHYbv1npBhWVhHEdIr51YhkGJ3tKhidVkBo=
 github.com/dogmatiq/cosyne v0.2.0 h1:tO957BpS4I9kqSw31ds6Ef4CXvV8zPAqWzbXKElsGWg=
 github.com/dogmatiq/cosyne v0.2.0/go.mod h1:dD8EZjbRX7FFw9t6P7l1nwoZbA7YxtOCfl9ZZAHPucU=
+github.com/dogmatiq/discoverkit v0.0.0-20210115020954-2f11f8a1362e h1:h0u8/jjr+i1FQX2+ecpf+nxKt49P2cnNdlJi2v4FW0g=
+github.com/dogmatiq/discoverkit v0.0.0-20210115020954-2f11f8a1362e/go.mod h1:EvUVp9/vhUOWfld6j+038h0ibB+jYIbM62HtpM7PxV4=
 github.com/dogmatiq/dodeca v0.2.2 h1:mxlHJSnaWc++JBp19o9invtEDG1sZy6q38697nnm5S8=
 github.com/dogmatiq/dodeca v0.2.2/go.mod h1:nrNDPFJiRLeBL3Ycyh6ZLs1ZgktpWS18Tze9qjXzTfg=
 github.com/dogmatiq/dogma v0.8.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
@@ -28,6 +32,9 @@ github.com/dogmatiq/envelopespec v0.2.0 h1:HWcc/N7uvPpeP0DNGGE+T6OoxHKFW72/JRq6+
 github.com/dogmatiq/envelopespec v0.2.0/go.mod h1:dc2AJXnhygv1HztUSBPnBhqTEpnXVPNexHsfPUpgeok=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
+github.com/dogmatiq/interopspec v0.4.0/go.mod h1:QyLUtAn28bQLqOamapIEjJzA9YG3lBsk8fTKRE3NX5E=
+github.com/dogmatiq/interopspec v0.4.1-0.20210107013954-d93daeb19c6b h1:5lcv3xCcSXh0f8V0vWx4EfRDz6lhYFl11TiIIBsi79Q=
+github.com/dogmatiq/interopspec v0.4.1-0.20210107013954-d93daeb19c6b/go.mod h1:QyLUtAn28bQLqOamapIEjJzA9YG3lBsk8fTKRE3NX5E=
 github.com/dogmatiq/kyu v0.2.0 h1:R3DH6W7IRe/Rtp5Wg9HgrJdNJtdZO6553ho0gFfLH7Y=
 github.com/dogmatiq/kyu v0.2.0/go.mod h1:g3oZX1sgN717QwJg5376fv4FlBukSxAEHjYjvPXA7SU=
 github.com/dogmatiq/linger v0.2.1 h1:ecVwiFlTcQuQ7ygQXH5bUPkWNve8n5BmVnCYMGMQ3zc=
@@ -43,6 +50,7 @@ github.com/emicklei/dot v0.15.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -76,7 +84,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.5 h1:kxhtnfFVi+rYdOALN0B3k9UT86zVJKfBimRaciULW4I=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -299,6 +306,8 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
+google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
+google.golang.org/grpc v1.34.1/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dogmatiq/configkit v0.8.0/go.mod h1:tJMAdqnx+H0q8mqBwp6z8NbnxRql/ImLgUyQkkip69A=
 github.com/dogmatiq/configkit v0.9.1/go.mod h1:lchVdCxCweenWrmm9WlgRH9X7Ppb340CvilcoVdTE8c=
-github.com/dogmatiq/configkit v0.9.2-0.20210112084953-158c931503a6 h1:EYSv4w5cxGa9FnLeRJM7mRJ3JQeRXTdT9KuNA0qlMns=
-github.com/dogmatiq/configkit v0.9.2-0.20210112084953-158c931503a6/go.mod h1:JVZG0CR5RHYbv1npBhWVhHEdIr51YhkGJ3tKhidVkBo=
+github.com/dogmatiq/configkit v0.10.0 h1:a6guEFPz3HrWDFvu2+5T3IxH4UiRwMnVtRFdYp06WKo=
+github.com/dogmatiq/configkit v0.10.0/go.mod h1:5/qN2Fcb1rwFqBF3XiBuaT6NkrcfUGbiVC+7R4vCTWk=
 github.com/dogmatiq/cosyne v0.2.0 h1:tO957BpS4I9kqSw31ds6Ef4CXvV8zPAqWzbXKElsGWg=
 github.com/dogmatiq/cosyne v0.2.0/go.mod h1:dD8EZjbRX7FFw9t6P7l1nwoZbA7YxtOCfl9ZZAHPucU=
-github.com/dogmatiq/discoverkit v0.0.0-20210115020954-2f11f8a1362e h1:h0u8/jjr+i1FQX2+ecpf+nxKt49P2cnNdlJi2v4FW0g=
-github.com/dogmatiq/discoverkit v0.0.0-20210115020954-2f11f8a1362e/go.mod h1:EvUVp9/vhUOWfld6j+038h0ibB+jYIbM62HtpM7PxV4=
+github.com/dogmatiq/discoverkit v0.1.1 h1:HjDzq6BiZLvX74qHQh7jq5mgD4vxnFfHW3Qn0DDHXx0=
+github.com/dogmatiq/discoverkit v0.1.1/go.mod h1:XZ5Xt/r2kLx+d+pOv3VFELasuRz5jQR9owR4v/zkR+c=
 github.com/dogmatiq/dodeca v0.2.2 h1:mxlHJSnaWc++JBp19o9invtEDG1sZy6q38697nnm5S8=
 github.com/dogmatiq/dodeca v0.2.2/go.mod h1:nrNDPFJiRLeBL3Ycyh6ZLs1ZgktpWS18Tze9qjXzTfg=
 github.com/dogmatiq/dogma v0.8.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
@@ -33,8 +33,8 @@ github.com/dogmatiq/envelopespec v0.2.0/go.mod h1:dc2AJXnhygv1HztUSBPnBhqTEpnXVP
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/dogmatiq/interopspec v0.4.0/go.mod h1:QyLUtAn28bQLqOamapIEjJzA9YG3lBsk8fTKRE3NX5E=
-github.com/dogmatiq/interopspec v0.4.1-0.20210107013954-d93daeb19c6b h1:5lcv3xCcSXh0f8V0vWx4EfRDz6lhYFl11TiIIBsi79Q=
-github.com/dogmatiq/interopspec v0.4.1-0.20210107013954-d93daeb19c6b/go.mod h1:QyLUtAn28bQLqOamapIEjJzA9YG3lBsk8fTKRE3NX5E=
+github.com/dogmatiq/interopspec v0.5.0 h1:R2oXavMLcATUre5h7NX8+rMhr4tkqXPtsEgOp6nsSeM=
+github.com/dogmatiq/interopspec v0.5.0/go.mod h1:30FOKEhMeiM6ZIpq8mQfE7LINrh1Jv7ukErZB79/mTg=
 github.com/dogmatiq/kyu v0.2.0 h1:R3DH6W7IRe/Rtp5Wg9HgrJdNJtdZO6553ho0gFfLH7Y=
 github.com/dogmatiq/kyu v0.2.0/go.mod h1:g3oZX1sgN717QwJg5376fv4FlBukSxAEHjYjvPXA7SU=
 github.com/dogmatiq/linger v0.2.1 h1:ecVwiFlTcQuQ7ygQXH5bUPkWNve8n5BmVnCYMGMQ3zc=
@@ -307,7 +307,6 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
-google.golang.org/grpc v1.34.1/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/network.go
+++ b/network.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	configapi "github.com/dogmatiq/configkit/api"
-	"github.com/dogmatiq/configkit/api/discovery"
 	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/discoverkit"
 	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/interopspec/configspec"
+	"github.com/dogmatiq/interopspec/discoverspec"
 	"github.com/dogmatiq/transportspec"
 	"github.com/dogmatiq/verity/eventstream/networkstream"
 	"github.com/dogmatiq/verity/eventstream/persistedstream"
@@ -21,13 +23,9 @@ import (
 func (e *Engine) runServer(ctx context.Context) error {
 	server := grpc.NewServer(e.opts.Network.ServerOptions...)
 
-	if err := e.registerConfigServer(ctx, server); err != nil {
-		return fmt.Errorf("unable to register config gRPC server: %w", err)
-	}
-
-	if err := e.registerEventStreamServer(ctx, server); err != nil {
-		return fmt.Errorf("unable to register event stream gRPC server: %w", err)
-	}
+	e.registerDiscoverAPI(server)
+	e.registerConfigAPI(server)
+	e.registerEventStreamAPI(server)
 
 	lis, err := net.Listen("tcp", e.opts.Network.ListenAddress)
 	if err != nil {
@@ -45,22 +43,36 @@ func (e *Engine) runServer(ctx context.Context) error {
 	return fmt.Errorf("gRPC server stopped: %w", err)
 }
 
-// registerConfigServer registers the Config server with the gRPC server.
-func (e *Engine) registerConfigServer(ctx context.Context, s *grpc.Server) error {
+// registerDiscoverServer registers the interopspec DiscoverAPI server with the
+// gRPC server.
+func (e *Engine) registerDiscoverAPI(s *grpc.Server) {
+	ds := &discoverkit.Server{}
+
+	for _, cfg := range e.opts.AppConfigs {
+		ds.Available(cfg.Identity())
+	}
+
+	discoverspec.RegisterDiscoverAPIServer(s, ds)
+}
+
+// registerConfigAPI registers the interopspec ConfigAPI server with the gRPC
+// server.
+func (e *Engine) registerConfigAPI(s *grpc.Server) {
 	// Convert slice of RichApplication to slice of Application so that we can
-	// pass it to the RegisterServer() function.
+	// pass it to the NewServer() function.
 	var configs []configkit.Application
 	for _, cfg := range e.opts.AppConfigs {
 		configs = append(configs, cfg)
 	}
 
-	configapi.RegisterServer(s, configs...)
-
-	return nil
+	configspec.RegisterConfigAPIServer(
+		s,
+		configapi.NewServer(configs...),
+	)
 }
 
-// registerConfigServer registers the EventStream server with the gRPC server.
-func (e *Engine) registerEventStreamServer(ctx context.Context, s *grpc.Server) error {
+// registerEventStreamAPI registers the EventStream server with the gRPC server.
+func (e *Engine) registerEventStreamAPI(s *grpc.Server) {
 	var options []networkstream.ServerOption
 
 	for k, a := range e.apps {
@@ -96,150 +108,101 @@ func (e *Engine) registerEventStreamServer(ctx context.Context, s *grpc.Server) 
 		e.opts.Marshaler,
 		options...,
 	)
-
-	return nil
 }
 
 // runDiscoverer runs the gRPC server discovery system.
 func (e *Engine) runDiscoverer(ctx context.Context) error {
-	logger := discoveryLogger{e.logger}
-
-	inspector := &discovery.Inspector{
-		Observer: discovery.NewApplicationObserverSet(
-			logger,
-			&discovery.ApplicationExecutor{Task: e.runDiscoveredApp},
-		),
-		Ignore: e.ignoreDiscoveredApp,
-	}
-
-	connector := &discovery.Connector{
-		Observer: discovery.NewClientObserverSet(
-			logger,
-			&discovery.ClientExecutor{
-				Task: func(ctx context.Context, c *discovery.Client) {
-					// TODO: add convenience methods to configkit for adding
-					// tasks to observer sets, including tasks that return
-					// errors. Perhaps a task-with-error could panic if the
-					// error is not context.Canceled.
-					inspector.Run(ctx, c)
-
-					// TODO: why is this needed? it's probably a remnant from
-					// when logging was performed with a defer.
-					<-ctx.Done()
-				},
-			},
-		),
+	d := &discoverkit.ApplicationDiscoverer{
 		Dial:            e.opts.Network.Dialer,
 		BackoffStrategy: e.opts.Network.DialerBackoff,
+		LogError: func(t discoverkit.Target, err error) {
+			logging.Debug(
+				e.logger,
+				"unable to discover applications on API server at %s: %s",
+				t.Name,
+				err,
+			)
+		},
 	}
 
-	err := e.opts.Network.Discoverer(
+	err := e.opts.Network.Discoverer.DiscoverTargets(
 		ctx,
-		discovery.NewTargetObserverSet(
-			logger,
-			&discovery.TargetExecutor{
-				Task: func(ctx context.Context, t *discovery.Target) {
-					// TODO: add convenience methods to configkit for adding
-					// tasks to observer sets, including tasks that return
-					// errors. Perhaps a task-with-error could panic if the
-					// error is not context.Canceled.
-					connector.Run(ctx, t)
-				},
-			},
-		),
+		func(ctx context.Context, t discoverkit.Target) {
+			go e.targetDiscovered(ctx, t, d)
+		},
 	)
 
 	return fmt.Errorf("discoverer stopped: %w", err)
 }
 
-// ignoreDiscoveredApp returns true if the discovered application should be
-// ignored because it is hosted by this engine.
-func (e *Engine) ignoreDiscoveredApp(a *discovery.Application) bool {
-	if _, ok := e.apps[a.Identity().Key]; !ok {
-		return false
-	}
-
+// targetDiscovered is called whenever a new gRPC target is discovered.
+func (e *Engine) targetDiscovered(
+	ctx context.Context,
+	t discoverkit.Target,
+	d *discoverkit.ApplicationDiscoverer,
+) {
 	logging.Debug(
 		e.logger,
-		"ignoring remote %s application at %s because it is hosted by this engine",
-		a.Identity(),
-		a.Client.Target.Name,
+		"discovered API server at %s",
+		t.Name,
 	)
 
-	return true
+	defer logging.Debug(
+		e.logger,
+		"lost API server at %s",
+		t.Name,
+	)
+
+	d.DiscoverApplications(
+		ctx,
+		t,
+		func(ctx context.Context, a discoverkit.Application) {
+			if _, ok := e.apps[a.Identity.Key]; ok {
+				logging.Debug(
+					e.logger,
+					"ignoring remote %s application at %s because it is hosted by this engine",
+					a.Identity,
+					a.Target.Name,
+				)
+
+				return
+			}
+
+			go e.targetDiscovered(ctx, t, d)
+		},
+	)
 }
 
 // runDiscoveredApp runs whatever processes need to run on this engine as a
 // result of discovering a remote application.
-func (e *Engine) runDiscoveredApp(ctx context.Context, a *discovery.Application) {
+func (e *Engine) runDiscoveredApp(ctx context.Context, a discoverkit.Application) {
+	logging.Log(
+		e.logger,
+		"found @%s application at %s, identity key is %s",
+		a.Identity.Name,
+		a.Target.Name,
+		a.Identity.Key,
+	)
+
+	defer logging.Log(
+		e.logger,
+		"lost @%s application at %s, identity key was %s",
+		a.Identity.Name,
+		a.Target.Name,
+		a.Identity.Key,
+	)
+
 	// err will only ever be context cancelation, as
 	// stream.Consumer always retries until ctx is canceled.
 	_ = e.runStreamConsumersForEachApp(
 		ctx,
 		&networkstream.Stream{
-			App:       a.Identity(),
-			Client:    transportspec.NewEventStreamClient(a.Client.Connection),
+			App:       a.Identity,
+			Client:    transportspec.NewEventStreamClient(a.Connection),
 			Marshaler: e.opts.Marshaler,
 			// TODO: https://github.com/dogmatiq/verity/issues/76
 			// Make pre-fetch buffer size configurable.
 			PreFetch: 10,
 		},
-	)
-}
-
-// discoveryLogger logs about discovery-related events.
-type discoveryLogger struct {
-	Logger logging.Logger
-}
-
-func (l discoveryLogger) TargetAvailable(t *discovery.Target) {
-	logging.Debug(
-		l.Logger,
-		"discovered API server at %s",
-		t.Name,
-	)
-}
-
-func (l discoveryLogger) TargetUnavailable(t *discovery.Target) {
-	logging.Debug(
-		l.Logger,
-		"lost API server at %s",
-		t.Name,
-	)
-}
-
-func (l discoveryLogger) ClientConnected(c *discovery.Client) {
-	logging.Debug(
-		l.Logger,
-		"connected to API server at %s",
-		c.Target.Name,
-	)
-}
-
-func (l discoveryLogger) ClientDisconnected(c *discovery.Client) {
-	logging.Debug(
-		l.Logger,
-		"disconnected from API server at %s",
-		c.Target.Name,
-	)
-}
-
-func (l discoveryLogger) ApplicationAvailable(a *discovery.Application) {
-	logging.Log(
-		l.Logger,
-		"found @%s application at %s, identity key is %s",
-		a.Identity().Name,
-		a.Client.Target.Name,
-		a.Identity().Key,
-	)
-}
-
-func (l discoveryLogger) ApplicationUnavailable(a *discovery.Application) {
-	logging.Log(
-		l.Logger,
-		"lost @%s application at %s, identity key was %s",
-		a.Identity().Name,
-		a.Client.Target.Name,
-		a.Identity().Key,
 	)
 }

--- a/networkoption.go
+++ b/networkoption.go
@@ -15,7 +15,7 @@ var (
 	// DefaultListenAddress is the default TCP address for the gRPC listener.
 	//
 	// It is overridden by the WithListenAddress() option.
-	DefaultListenAddress = ":50555"
+	DefaultListenAddress = net.JoinHostPort("", discoverkit.DefaultGRPCPort)
 
 	// DefaultDialer is the default dialer used to connect to other engine's
 	// gRPC servers.

--- a/networkoption.go
+++ b/networkoption.go
@@ -1,12 +1,11 @@
 package verity
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"time"
 
-	"github.com/dogmatiq/configkit/api/discovery"
+	"github.com/dogmatiq/discoverkit"
 	"github.com/dogmatiq/linger"
 	"github.com/dogmatiq/linger/backoff"
 	"google.golang.org/grpc"
@@ -22,7 +21,7 @@ var (
 	// gRPC servers.
 	//
 	// It is overridden by the WithDialer() option.
-	DefaultDialer = discovery.DefaultDialer
+	DefaultDialer discoverkit.Dialer = grpc.DialContext
 
 	// DefaultDialerBackoff is the default backoff strategy for gRPC dialer
 	// retries.
@@ -38,10 +37,7 @@ var (
 	// instances on the network.
 	//
 	// It is overridden by the WithDiscoverer() option.
-	DefaultDiscoverer = func(ctx context.Context, _ discovery.TargetObserver) error {
-		<-ctx.Done()
-		return ctx.Err()
-	}
+	DefaultDiscoverer discoverkit.TargetDiscoverer = discoverkit.StaticTargetDiscoverer{}
 )
 
 // NetworkOption configures the networking-related behavior of an engine.
@@ -91,7 +87,7 @@ func WithServerOptions(options ...grpc.ServerOption) NetworkOption {
 // other engine's gRPC servers.
 //
 // If this option is omitted or d is nil, DefaultDialer is used.
-func WithDialer(d discovery.Dialer) NetworkOption {
+func WithDialer(d discoverkit.Dialer) NetworkOption {
 	return func(opts *networkOptions) {
 		opts.Dialer = d
 	}
@@ -107,20 +103,14 @@ func WithDialerBackoff(s backoff.Strategy) NetworkOption {
 	}
 }
 
-// Discoverer is a function that notifies an observer when a config API target
-// becomes available or unavailable.
-//
-// It blocks until ctx is canceled or a fatal error occurs.
-type Discoverer func(ctx context.Context, o discovery.TargetObserver) error
-
 // WithDiscoverer returns a network option that sets the discoverer used to find
 // other engine instances on the network.
 //
 // Currently this option MUST be specified.
 //
-// TODO: https://github.com/dogmatiq/configkit/issues/58
+// TODO: https://github.com/dogmatiq/discoverkit/issues/2
 // Use Bonjour as the default discovery mechanism.
-func WithDiscoverer(d Discoverer) NetworkOption {
+func WithDiscoverer(d discoverkit.TargetDiscoverer) NetworkOption {
 	return func(opts *networkOptions) {
 		opts.Discoverer = d
 	}
@@ -130,9 +120,9 @@ func WithDiscoverer(d Discoverer) NetworkOption {
 type networkOptions struct {
 	ListenAddress string
 	ServerOptions []grpc.ServerOption
-	Dialer        discovery.Dialer
+	Dialer        discoverkit.Dialer
 	DialerBackoff backoff.Strategy
-	Discoverer    Discoverer
+	Discoverer    discoverkit.TargetDiscoverer
 }
 
 // resolveNetworkOptions returns a fully-populated set of network options built


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes the engine to use discovery features from the new `discoverkit` module and the new version of the config API implemented by `configkit`, both of which are based on gRPC definitions in the `interopspec`.

#### Why make this change?

This is part of a larger change to consolidate all of the "interoperability APIs" into the `interopspec` repo. 

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None