### PR TITLE
[WIP] Add compatibility for MariaDB 10.2

### DIFF
--- a/persistence/sqlpersistence/mysql/driver.go
+++ b/persistence/sqlpersistence/mysql/driver.go
@@ -20,7 +20,7 @@ func (driver) IsCompatibleWith(ctx context.Context, db *sql.DB) error {
 	// Verify that ?-style placeholders are supported.
 	err := db.QueryRowContext(
 		ctx,
-		`SELECT 1 WHERE 1 = ?`,
+		`SELECT ?`,
 		1,
 	).Err()
 


### PR DESCRIPTION
From local testing, the proposed change allows verity to start up with both MariaDB 10.2 and 10.4. I'll need to verify the rest.

