### PR TITLE
Implement event stream content negotiation.

### DIFF
--- a/eventstream/networkstream/server.go
+++ b/eventstream/networkstream/server.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/interopspec/envelopespec"
 	"github.com/dogmatiq/interopspec/eventstreamspec"
 	"github.com/dogmatiq/marshalkit"
 	"github.com/dogmatiq/verity/eventstream"
 	"github.com/dogmatiq/verity/internal/x/grpcx"
+	"github.com/dogmatiq/verity/parcel"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -138,12 +140,12 @@ func (s *server) Consume(
 ) error {
 	ctx := consumer.Context()
 
-	types, err := s.unmarshalTypes(req)
+	messageTypes, mediaTypes, err := s.unmarshalTypes(req)
 	if err != nil {
 		return err
 	}
 
-	cur, err := s.stream.Open(ctx, req.GetOffset(), types)
+	cur, err := s.stream.Open(ctx, req.GetOffset(), messageTypes)
 	if err != nil {
 		return err
 	}
@@ -155,9 +157,14 @@ func (s *server) Consume(
 			return err
 		}
 
+		env, err := s.transcode(ev.Parcel, mediaTypes)
+		if err != nil {
+			return err
+		}
+
 		res := &eventstreamspec.ConsumeResponse{
 			Offset:   ev.Offset,
-			Envelope: ev.Parcel.Envelope,
+			Envelope: env,
 		}
 
 		if err := consumer.Send(res); err != nil {
@@ -176,40 +183,97 @@ func (s *server) EventTypes(
 	return s.resp, nil
 }
 
-func (s *server) unmarshalTypes(req *eventstreamspec.ConsumeRequest) (message.TypeCollection, error) {
+// unmarshalTypes unmarshals the event types, and their respective media-types
+// from the given request.
+func (s *server) unmarshalTypes(
+	req *eventstreamspec.ConsumeRequest,
+) (
+	message.TypeCollection,
+	map[string][]string,
+	error,
+) {
+	if len(req.GetEventTypes()) == 0 {
+		return nil, nil, grpcx.Errorf(
+			codes.InvalidArgument,
+			nil,
+			"at least one event type must be consumed",
+		)
+	}
+
 	var (
-		types  = message.TypeSet{}
-		failed []proto.Message
+		messageTypes = message.TypeSet{}
+		mediaTypes   = map[string][]string{}
+		failures     []proto.Message
 	)
 
 	for _, et := range req.GetEventTypes() {
 		n := et.GetPortableName()
 
 		if mt, ok := s.types[n]; ok {
-			types.Add(mt)
+			messageTypes.Add(mt)
+			mediaTypes[n] = et.GetMediaTypes()
 		} else {
-			failed = append(
-				failed,
+			failures = append(
+				failures,
 				&eventstreamspec.UnrecognizedEventType{PortableName: n},
 			)
 		}
 	}
 
-	if len(failed) > 0 {
-		return nil, grpcx.Errorf(
+	if len(failures) > 0 {
+		return nil, nil, grpcx.Errorf(
 			codes.InvalidArgument,
-			failed,
-			"unrecognized message type(s)",
+			failures,
+			"one or more unrecognized event types or media-types",
 		)
 	}
 
-	if len(types) == 0 {
+	return messageTypes, mediaTypes, nil
+}
+
+// transcope returns an envelope containing the message in p, transcoded into a
+// media-type supported by the client.
+func (s *server) transcode(
+	p parcel.Parcel,
+	mediaTypes map[string][]string,
+) (*envelopespec.Envelope, error) {
+	n := p.Envelope.GetPortableName()
+	preferredMediaTypes := mediaTypes[n]
+
+	// First see if the existing format is supported by the client at all. It
+	// may not be their first preference, but if it is supported we can send the
+	// message packet without marshaling it again.
+	for _, mt := range preferredMediaTypes {
+		if p.Envelope.GetMediaType() == mt {
+			return p.Envelope, nil
+		}
+	}
+
+	// Otherwise, attempt to marshal the message using the client's requested
+	// media-types in order of preference.
+	packet, ok, err := s.marshaler.MarshalAs(p.Message, preferredMediaTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	// None of the supplied media-types are supported by the marshaler so
+	// there's no way to supply this event to the client.
+	if !ok {
 		return nil, grpcx.Errorf(
 			codes.InvalidArgument,
-			nil,
-			"message types can not be empty",
+			[]proto.Message{
+				&eventstreamspec.NoRecognizedMediaTypes{
+					PortableName: n,
+				},
+			},
+			"none of the requested media-types for '%s' events are supported",
+			n,
 		)
 	}
 
-	return types, nil
+	env := proto.Clone(p.Envelope).(*envelopespec.Envelope)
+	env.MediaType = packet.MediaType
+	env.Data = packet.Data
+
+	return env, nil
 }

--- a/eventstream/networkstream/server.go
+++ b/eventstream/networkstream/server.go
@@ -231,7 +231,7 @@ func (s *server) unmarshalTypes(
 	return messageTypes, mediaTypes, nil
 }
 
-// transcope returns an envelope containing the message in p, transcoded into a
+// transcode returns an envelope containing the message in p, transcoded into a
 // media-type supported by the client.
 func (s *server) transcode(
 	p parcel.Parcel,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dogmatiq/interopspec v0.5.0
 	github.com/dogmatiq/kyu v0.2.0
 	github.com/dogmatiq/linger v0.2.1
-	github.com/dogmatiq/marshalkit v0.5.1-0.20210129012837-0023540ca5ee
+	github.com/dogmatiq/marshalkit v0.6.0
 	github.com/dogmatiq/sqltest v0.3.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/dogmatiq/kyu v0.2.0 h1:R3DH6W7IRe/Rtp5Wg9HgrJdNJtdZO6553ho0gFfLH7Y=
 github.com/dogmatiq/kyu v0.2.0/go.mod h1:g3oZX1sgN717QwJg5376fv4FlBukSxAEHjYjvPXA7SU=
 github.com/dogmatiq/linger v0.2.1 h1:ecVwiFlTcQuQ7ygQXH5bUPkWNve8n5BmVnCYMGMQ3zc=
 github.com/dogmatiq/linger v0.2.1/go.mod h1:vQPEiGNtb3Qy+1IdmdSMyLxr4d9vPChknnQkClQimGM=
-github.com/dogmatiq/marshalkit v0.5.1-0.20210129012837-0023540ca5ee h1:2lRuEc+LQ4776IHIPTbibC6i8bIe9v9YAL5ZDZx96ok=
-github.com/dogmatiq/marshalkit v0.5.1-0.20210129012837-0023540ca5ee/go.mod h1:IMBaNe+XCvCejjk+so9sBOY+HoSsnEM8YTs5l12HsV0=
+github.com/dogmatiq/marshalkit v0.6.0 h1:rXQv7WDmT9cF3KJMUCRis5/gDCcC7wVxl37zfMMb970=
+github.com/dogmatiq/marshalkit v0.6.0/go.mod h1:u/McAis2z8oP4wqCQzXriCqEHc6u+G7L2ADNxalHngY=
 github.com/dogmatiq/sqltest v0.3.0 h1:DCwyLWfVk/ZHsqq5Itq3H/Lqsh/CIQ6nIRwI4YLywFc=
 github.com/dogmatiq/sqltest v0.3.0/go.mod h1:a8Da8NhU4m3lq5Sybhiv+ZQowSnGHWTIJHFNInVtffg=
 github.com/emicklei/dot v0.15.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
@@ -48,6 +48,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
+github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -166,7 +168,6 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.12.3/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
@@ -176,7 +177,6 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.10.4 h1:NiTx7EEvBzu9sFOD1zORteLSt3o8gnlvZZwSE9TnY9U=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
 github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
@@ -203,6 +203,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
@@ -272,7 +274,6 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -296,7 +297,6 @@ golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds support for basic content-type negotiation for event messages based on the MIME media-type.

The rules are:

1. If the client supports the existing encoding of the message, it is sent unchanged
2. Otherwise, it is re-encoded using the client's most-preferred media-type that is also supported by the server.

#### Why make this change?

This is somewhat of a future proofing measure that lets us consume events in different formats to how they are persisted in the event stream if necessary.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
