### PR TITLE
Validate events in consumer.

### DIFF
--- a/eventstream/consumer_test.go
+++ b/eventstream/consumer_test.go
@@ -293,6 +293,41 @@ var _ = Describe("type Consumer", func() {
 			Expect(err).To(Equal(context.Canceled))
 		})
 
+		It("restarts the consumer if the event's source application does not match the consumer's application", func() {
+			// Make event0 use a different source application to the one that
+			// the consumer is expecting to see.
+			event0.Parcel.Envelope.SourceApplication.Key = "<different>"
+
+			// Configure the handler to start at offset 0, but then try offset 2
+			// on the next attempt.
+			isRetry := false
+			eshandler.NextOffsetFunc = func(
+				context.Context,
+				configkit.Identity,
+			) (uint64, error) {
+				if isRetry {
+					return 2, nil
+				}
+
+				isRetry = true
+				return 0, nil
+			}
+
+			eshandler.HandleEventFunc = func(
+				_ context.Context,
+				_ uint64,
+				ev Event,
+			) error {
+				// We should only ever be passed the event at offset 2.
+				Expect(ev).To(Equal(event2))
+				cancel()
+				return nil
+			}
+
+			err := consumer.Run(ctx)
+			Expect(err).To(Equal(context.Canceled))
+		})
+
 		It("returns if the context is canceled", func() {
 			cancel()
 			err := consumer.Run(ctx)

--- a/eventstream/networkstream/cursor.go
+++ b/eventstream/networkstream/cursor.go
@@ -96,11 +96,13 @@ func (c *cursor) recv() error {
 		return err
 	}
 
+	env := res.GetEnvelope()
+
 	ev := eventstream.Event{
 		Offset: res.Offset,
 	}
 
-	ev.Parcel, err = parcel.FromEnvelope(c.marshaler, res.GetEnvelope())
+	ev.Parcel, err = parcel.FromEnvelope(c.marshaler, env)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes the event consumer to perform some basic sanity checks on the events received from the stream.

#### Why make this change?

This is in response to an issue where a misbehaving streamspec implementation was returning the wrong source application key. This incorrect application key was passed on to the projection handler (luckily) resulting in an OCC failure.

These changes prevent such an event from getting that far, and also provide a much more meaningful error message.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
