### PR TITLE
Add `queue.StreamAdaptor`.

### DIFF
--- a/engineoption.go
+++ b/engineoption.go
@@ -184,6 +184,14 @@ func NewDefaultMarshaler(configs []configkit.RichApplication) marshalkit.Marshal
 		for t := range cfg.MessageTypes().All() {
 			types = append(types, t.ReflectType())
 		}
+
+		cfg.RichHandlers().RangeProcesses(
+			func(h configkit.RichProcess) bool {
+				r := h.Handler().New()
+				types = append(types, reflect.TypeOf(r))
+				return true
+			},
+		)
 	}
 
 	m, err := codec.NewMarshaler(

--- a/queue/executor_test.go
+++ b/queue/executor_test.go
@@ -61,9 +61,10 @@ var _ = Describe("type CommandExecutor", func() {
 	})
 
 	JustBeforeEach(func() {
+		q := queue
 		go func() {
 			defer GinkgoRecover()
-			queue.Run(ctx)
+			q.Run(ctx)
 		}()
 	})
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -85,9 +85,10 @@ var _ = Describe("type Queue", func() {
 
 	When("the queue is running", func() {
 		JustBeforeEach(func() {
+			q := queue
 			go func() {
 				defer GinkgoRecover()
-				err := queue.Run(ctx)
+				err := q.Run(ctx)
 				Expect(err).To(Equal(context.Canceled))
 			}()
 		})

--- a/queue/stream.go
+++ b/queue/stream.go
@@ -1,0 +1,62 @@
+package queue
+
+import (
+	"context"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/verity/eventstream"
+	"github.com/dogmatiq/verity/persistence"
+)
+
+// StreamAdaptor is an eventstream.Handler that adds the consumed events to a
+// queue.
+type StreamAdaptor struct {
+	Queue            *Queue
+	OffsetRepository persistence.OffsetRepository
+	Persister        persistence.Persister
+}
+
+// NextOffset returns the offset of the next event to be consumed from a
+// specific application's event stream.
+//
+// id is the identity of the source application.
+func (a *StreamAdaptor) NextOffset(ctx context.Context, id configkit.Identity) (uint64, error) {
+	return a.OffsetRepository.LoadOffset(ctx, id.Key)
+}
+
+// HandleEvent handles an event obtained from the event stream.
+//
+// o must be the offset that would be returned by NextOffset(). On success,
+// the next call to NextOffset() will return ev.Offset + 1.
+func (a *StreamAdaptor) HandleEvent(ctx context.Context, o uint64, ev eventstream.Event) error {
+	qm := persistence.QueueMessage{
+		NextAttemptAt: ev.Parcel.CreatedAt,
+		Envelope:      ev.Parcel.Envelope,
+	}
+
+	if _, err := a.Persister.Persist(
+		ctx,
+		persistence.Batch{
+			persistence.SaveQueueMessage{
+				Message: qm,
+			},
+			persistence.SaveOffset{
+				ApplicationKey: ev.Parcel.Envelope.GetSourceApplication().GetKey(),
+				CurrentOffset:  o,
+				NextOffset:     o + 1,
+			},
+		},
+	); err != nil {
+		return err
+	}
+
+	qm.Revision++
+
+	a.Queue.Add(
+		[]Message{
+			{qm, ev.Parcel},
+		},
+	)
+
+	return nil
+}

--- a/queue/stream.go
+++ b/queue/stream.go
@@ -43,7 +43,7 @@ func (a *StreamAdaptor) HandleEvent(ctx context.Context, o uint64, ev eventstrea
 			persistence.SaveOffset{
 				ApplicationKey: ev.Parcel.Envelope.GetSourceApplication().GetKey(),
 				CurrentOffset:  o,
-				NextOffset:     o + 1,
+				NextOffset:     ev.Offset + 1,
 			},
 		},
 	); err != nil {

--- a/queue/stream_test.go
+++ b/queue/stream_test.go
@@ -1,0 +1,151 @@
+package queue_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/configkit"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/marshalkit/fixtures"
+	"github.com/dogmatiq/verity/eventstream"
+	. "github.com/dogmatiq/verity/fixtures"
+	"github.com/dogmatiq/verity/parcel"
+	"github.com/dogmatiq/verity/persistence"
+	. "github.com/dogmatiq/verity/queue"
+	. "github.com/jmalloc/gomegax"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type StreamAdaptor", func() {
+	var (
+		ctx       context.Context
+		cancel    context.CancelFunc
+		dataStore *DataStoreStub
+		queue     *Queue
+		parcel    parcel.Parcel
+		event     eventstream.Event
+		adaptor   *StreamAdaptor
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+
+		parcel = NewParcel("<message-0>", MessageE1)
+		event = eventstream.Event{
+			Offset: 123,
+			Parcel: parcel,
+		}
+
+		dataStore = NewDataStoreStub()
+
+		queue = &Queue{
+			Repository: dataStore,
+			Marshaler:  Marshaler,
+		}
+
+		adaptor = &StreamAdaptor{
+			Queue:            queue,
+			OffsetRepository: dataStore,
+			Persister:        dataStore,
+		}
+
+		q := queue
+		go func() {
+			defer GinkgoRecover()
+			err := q.Run(ctx)
+			Expect(err).To(Equal(context.Canceled))
+		}()
+	})
+
+	AfterEach(func() {
+		dataStore.Close()
+		cancel()
+	})
+
+	Describe("func NextOffset()", func() {
+		It("loads the next offset from the offset repository", func() {
+			_, err := dataStore.Persist(
+				ctx,
+				persistence.Batch{
+					persistence.SaveOffset{
+						ApplicationKey: "<app-key>",
+						CurrentOffset:  0,
+						NextOffset:     123,
+					},
+				},
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			o, err := adaptor.NextOffset(
+				ctx,
+				configkit.MustNewIdentity(
+					"<app-name>",
+					"<app-key>",
+				),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(o).To(BeNumerically("==", 123))
+		})
+	})
+
+	Describe("func HandleEvent()", func() {
+		It("persists the event to the queue", func() {
+			err := adaptor.HandleEvent(
+				ctx,
+				0,
+				event,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			messages, err := dataStore.LoadQueueMessages(ctx, 1)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(messages).To(HaveLen(1))
+			Expect(messages[0].Envelope).To(EqualX(parcel.Envelope))
+		})
+
+		It("updates the next offset", func() {
+			err := adaptor.HandleEvent(
+				ctx,
+				0,
+				event,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			o, err := dataStore.LoadOffset(ctx, "<app-key>")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(o).To(BeNumerically("==", 124))
+		})
+
+		It("pushes the event into the in-memory queue", func() {
+			err := adaptor.HandleEvent(
+				ctx,
+				0,
+				event,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			m, err := queue.Pop(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(m.Revision).To(BeNumerically("==", 1))
+			Expect(m.Parcel).To(EqualX(parcel))
+		})
+
+		It("returns an error if the current offset is incorrect", func() {
+			err := adaptor.HandleEvent(
+				ctx,
+				1,
+				event,
+			)
+			Expect(err).To(Equal(
+				persistence.ConflictError{
+					Cause: persistence.SaveOffset{
+						ApplicationKey: "<app-key>",
+						CurrentOffset:  1,
+						NextOffset:     124,
+					},
+				},
+			))
+		})
+	})
+})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR introduces `queue.StreamAdaptor`, which is an `eventstream.Handler` that places messages into a `queue.Queue`. It also includes the necessary glue code to consume events from each discovered application.

#### Why make this change?

This mechanism is required to obtain events produced by "other" applications that are consumed by process message handlers within "this" application.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
