### PR TITLE
Explicitly format `time.Duration` as postgres intervals.

### DIFF
--- a/persistence/sqlpersistence/postgres/lock.go
+++ b/persistence/sqlpersistence/postgres/lock.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/dogmatiq/verity/internal/x/sqlx"
@@ -39,7 +40,10 @@ func (driver) AcquireLock(
 		) ON CONFLICT (app_key) DO NOTHING
 		RETURNING id`,
 		ak,
-		ttl,
+		fmt.Sprintf(
+			"%d MICROSECONDS",
+			ttl.Microseconds(),
+		),
 	)
 
 	var id int64
@@ -70,7 +74,10 @@ func (driver) RenewLock(
 			expires_at = CURRENT_TIMESTAMP + $1
 		WHERE id = $2
 		AND expires_at > CURRENT_TIMESTAMP`,
-		ttl,
+		fmt.Sprintf(
+			"%d MICROSECONDS",
+			ttl.Microseconds(),
+		),
 		id,
 	), nil
 }


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR explicitly formats `time.Duration` types as PostgreSQL interval strings, instead of relying on the database driver to do it.

#### Why make this change?

The `lib/pq` driver does not support converting `time.Duration` to interval types, see https://github.com/lib/pq/issues/78).

#### Is there anything you are unsure about?

It seems that the official `db/sql` package doesn't really support `time.Duration` either, see https://github.com/golang/go/issues/4954. It _might_ be best to ensure we don't pass `time.Duration` for _any_ SQL drivers/products, though it is working for the others right now.

#### What issues does this relate to?

Fixes #423.
