### PR TITLE
Test all supported SQL product/driver combinations.

### DIFF
--- a/persistence/sqlpersistence/mysql/driver_test.go
+++ b/persistence/sqlpersistence/mysql/driver_test.go
@@ -20,36 +20,38 @@ var _ = Describe("type driver", func() {
 		db       *sql.DB
 	)
 
-	providertest.Declare(
-		func(ctx context.Context, in providertest.In) providertest.Out {
-			var err error
-			database, err = sqltest.NewDatabase(ctx, sqltest.MySQLDriver, sqltest.MySQL)
-			Expect(err).ShouldNot(HaveOccurred())
+	for _, pair := range sqltest.CompatiblePairs(sqltest.MySQL, sqltest.MariaDB) {
+		providertest.Declare(
+			func(ctx context.Context, in providertest.In) providertest.Out {
+				var err error
+				database, err = sqltest.NewDatabase(ctx, pair.Driver, pair.Product)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			db, err = database.Open()
-			Expect(err).ShouldNot(HaveOccurred())
+				db, err = database.Open()
+				Expect(err).ShouldNot(HaveOccurred())
 
-			err = Driver.CreateSchema(ctx, db)
-			Expect(err).ShouldNot(HaveOccurred())
+				err = Driver.CreateSchema(ctx, db)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			return providertest.Out{
-				NewProvider: func() (persistence.Provider, func()) {
-					return &veritysql.Provider{
-						DB: db,
-					}, nil
-				},
-				IsShared: true,
-			}
-		},
-		func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			defer cancel()
+				return providertest.Out{
+					NewProvider: func() (persistence.Provider, func()) {
+						return &veritysql.Provider{
+							DB: db,
+						}, nil
+					},
+					IsShared: true,
+				}
+			},
+			func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				defer cancel()
 
-			err := Driver.DropSchema(ctx, db)
-			Expect(err).ShouldNot(HaveOccurred())
+				err := Driver.DropSchema(ctx, db)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			err = database.Close()
-			Expect(err).ShouldNot(HaveOccurred())
-		},
-	)
+				err = database.Close()
+				Expect(err).ShouldNot(HaveOccurred())
+			},
+		)
+	}
 })

--- a/persistence/sqlpersistence/postgres/driver_test.go
+++ b/persistence/sqlpersistence/postgres/driver_test.go
@@ -20,36 +20,38 @@ var _ = Describe("type driver", func() {
 		db       *sql.DB
 	)
 
-	providertest.Declare(
-		func(ctx context.Context, in providertest.In) providertest.Out {
-			var err error
-			database, err = sqltest.NewDatabase(ctx, sqltest.PGXDriver, sqltest.PostgreSQL)
-			Expect(err).ShouldNot(HaveOccurred())
+	for _, pair := range sqltest.CompatiblePairs(sqltest.PostgreSQL) {
+		providertest.Declare(
+			func(ctx context.Context, in providertest.In) providertest.Out {
+				var err error
+				database, err = sqltest.NewDatabase(ctx, pair.Driver, pair.Product)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			db, err = database.Open()
-			Expect(err).ShouldNot(HaveOccurred())
+				db, err = database.Open()
+				Expect(err).ShouldNot(HaveOccurred())
 
-			err = Driver.CreateSchema(ctx, db)
-			Expect(err).ShouldNot(HaveOccurred())
+				err = Driver.CreateSchema(ctx, db)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			return providertest.Out{
-				NewProvider: func() (persistence.Provider, func()) {
-					return &veritysql.Provider{
-						DB: db,
-					}, nil
-				},
-				IsShared: true,
-			}
-		},
-		func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			defer cancel()
+				return providertest.Out{
+					NewProvider: func() (persistence.Provider, func()) {
+						return &veritysql.Provider{
+							DB: db,
+						}, nil
+					},
+					IsShared: true,
+				}
+			},
+			func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				defer cancel()
 
-			err := Driver.DropSchema(ctx, db)
-			Expect(err).ShouldNot(HaveOccurred())
+				err := Driver.DropSchema(ctx, db)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			err = database.Close()
-			Expect(err).ShouldNot(HaveOccurred())
-		},
-	)
+				err = database.Close()
+				Expect(err).ShouldNot(HaveOccurred())
+			},
+		)
+	}
 })

--- a/persistence/sqlpersistence/postgres/lock.go
+++ b/persistence/sqlpersistence/postgres/lock.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/dogmatiq/verity/internal/x/sqlx"
@@ -39,7 +40,10 @@ func (driver) AcquireLock(
 		) ON CONFLICT (app_key) DO NOTHING
 		RETURNING id`,
 		ak,
-		ttl,
+		fmt.Sprintf(
+			"%d MICROSECONDS",
+			ttl.Microseconds(),
+		),
 	)
 
 	var id int64
@@ -70,7 +74,10 @@ func (driver) RenewLock(
 			expires_at = CURRENT_TIMESTAMP + $1
 		WHERE id = $2
 		AND expires_at > CURRENT_TIMESTAMP`,
-		ttl,
+		fmt.Sprintf(
+			"%d MICROSECONDS",
+			ttl.Microseconds(),
+		),
 		id,
 	), nil
 }

--- a/persistence/sqlpersistence/sqlite/driver_test.go
+++ b/persistence/sqlpersistence/sqlite/driver_test.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package sqlite_test
@@ -22,36 +23,38 @@ var _ = Describe("type driver", func() {
 		db       *sql.DB
 	)
 
-	providertest.Declare(
-		func(ctx context.Context, in providertest.In) providertest.Out {
-			var err error
-			database, err = sqltest.NewDatabase(ctx, sqltest.SQLite3Driver, sqltest.SQLite)
-			Expect(err).ShouldNot(HaveOccurred())
+	for _, pair := range sqltest.CompatiblePairs(sqltest.SQLite) {
+		providertest.Declare(
+			func(ctx context.Context, in providertest.In) providertest.Out {
+				var err error
+				database, err = sqltest.NewDatabase(ctx, pair.Driver, pair.Product)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			db, err = database.Open()
-			Expect(err).ShouldNot(HaveOccurred())
+				db, err = database.Open()
+				Expect(err).ShouldNot(HaveOccurred())
 
-			err = Driver.CreateSchema(ctx, db)
-			Expect(err).ShouldNot(HaveOccurred())
+				err = Driver.CreateSchema(ctx, db)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			return providertest.Out{
-				NewProvider: func() (persistence.Provider, func()) {
-					return &veritysql.Provider{
-						DB: db,
-					}, nil
-				},
-				IsShared: true,
-			}
-		},
-		func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			defer cancel()
+				return providertest.Out{
+					NewProvider: func() (persistence.Provider, func()) {
+						return &veritysql.Provider{
+							DB: db,
+						}, nil
+					},
+					IsShared: true,
+				}
+			},
+			func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				defer cancel()
 
-			err := Driver.DropSchema(ctx, db)
-			Expect(err).ShouldNot(HaveOccurred())
+				err := Driver.DropSchema(ctx, db)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			err = database.Close()
-			Expect(err).ShouldNot(HaveOccurred())
-		},
-	)
+				err = database.Close()
+				Expect(err).ShouldNot(HaveOccurred())
+			},
+		)
+	}
 })


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes the SQL provider tests all product and driver combinations using `sqltest.CompatiblePairs()`.

#### Why make this change?

Previously, MariaDB and the `lib/pq` PostgreSQL driver were never being tested.

#### Is there anything you are unsure about?

I did say in #205 that there's probably not much point supporting `lib/pq` anymore, but it's not costing us anything at the moment so I will leave it there.

#### What issues does this relate to?

Fixes #425
