### PR TITLE
Require empty media-type when detecting stateless process roots.

### DIFF
--- a/handler/process/adaptor.go
+++ b/handler/process/adaptor.go
@@ -196,6 +196,8 @@ func (a *Adaptor) save(
 	id string,
 	inst *Instance,
 ) error {
+	// An empty packet represents a stateless process root, so we only populate
+	// the packet if the root is stafeful.
 	if inst.Root != dogma.StatelessProcessRoot {
 		var err error
 		inst.Packet, err = a.Marshaler.Marshal(inst.Root)

--- a/handler/process/loader.go
+++ b/handler/process/loader.go
@@ -44,7 +44,8 @@ func (l *Loader) Load(
 		return inst, nil
 	}
 
-	if len(persisted.Packet.Data) == 0 {
+	// An empty packet represents a stateless process root.
+	if persisted.Packet.MediaType == "" && len(persisted.Packet.Data) == 0 {
 		inst.Root = dogma.StatelessProcessRoot
 		return inst, nil
 	}

--- a/persistence/sqlpersistence/provider_test.go
+++ b/persistence/sqlpersistence/provider_test.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package sqlpersistence_test


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR requires a process root's binary packet to have an empty media type in order for the process root to be treated as "stateless".

#### Why make this change?

Previously this code only checked that the packet's data was empty. This caused a false positive when some other (stateful) process root was persisted but just happened to have all default values - specifically, the empty data buffer is a valid representation of a zero-value protocol buffers message.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
