### PR TITLE
Use same entity key for `SaveProcessInstance` and `RemoveProcessInstance` operations.

### DIFF
--- a/persistence/process.go
+++ b/persistence/process.go
@@ -50,7 +50,7 @@ func (op SaveProcessInstance) AcceptVisitor(ctx context.Context, v OperationVisi
 }
 
 func (op SaveProcessInstance) entityKey() entityKey {
-	return entityKey{"process", op.Instance.HandlerKey, op.Instance.InstanceID}
+	return entityKey{"handler", op.Instance.HandlerKey, op.Instance.InstanceID}
 }
 
 // RemoveProcessInstance is an Operation that removes a process instance.


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

Change the "entity key" of `SaveProcessInstance` to match `RemoveProcessInstance`.

#### Why make this change?

So that these two operations can not be performed on the same process instance in the same batch.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
